### PR TITLE
RequiredShares calculation fix

### DIFF
--- a/contracts/SushiYieldSource.sol
+++ b/contracts/SushiYieldSource.sol
@@ -59,9 +59,10 @@ contract SushiYieldSource is IYieldSource {
         balances[to] = balances[to].add(balanceDiff);
     }
 
-    /// @notice Redeems tokens from the yield source from the msg.sender, it burn yield bearing tokens and return token to the sender.
+    /// @notice Redeems tokens from the yield source to the msg.sender, it burns yield bearing tokens and returns token to the sender.
     /// @param amount The amount of `token()` to withdraw.  Denominated in `token()` as above.
-    /// @return The actual amount of tokens that were redeemed.
+    /// @dev The maxiumum that can be called for token() is calculated by balanceOfToken() above.
+    /// @return The actual amount of tokens that were redeemed. This may be different from the amount passed due to the fractional math involved. 
     function redeemToken(uint256 amount) public override returns (uint256) {
         ISushiBar bar = sushiBar;
         ISushi sushi = sushiAddr;

--- a/contracts/SushiYieldSource.sol
+++ b/contracts/SushiYieldSource.sol
@@ -74,7 +74,7 @@ contract SushiYieldSource is IYieldSource {
 
         uint256 sushiBeforeBalance = sushi.balanceOf(address(this));
 
-        uint requiredShares = ((amount.mul(totalShares) + totalShares.sub(1))).div(barSushiBalance);
+        uint requiredShares = (((amount.mul(totalShares) + totalShares)).div(barSushiBalance)).sub(1);
         bar.leave(requiredShares);
 
         uint256 sushiAfterBalance = sushi.balanceOf(address(this));

--- a/contracts/SushiYieldSource.sol
+++ b/contracts/SushiYieldSource.sol
@@ -75,14 +75,17 @@ contract SushiYieldSource is IYieldSource {
 
         uint256 sushiBeforeBalance = sushi.balanceOf(address(this));
 
-        uint requiredShares = (((amount.mul(totalShares) + totalShares)).div(barSushiBalance)).sub(1);
-        bar.leave(requiredShares);
+        uint256 requiredShares = ((amount.mul(totalShares) + totalShares)).div(barSushiBalance);
+        if(requiredShares == 0) return 0;
+        
+        uint256 requiredSharesBalance = requiredShares.sub(1);
+        bar.leave(requiredSharesBalance);
 
         uint256 sushiAfterBalance = sushi.balanceOf(address(this));
         
         uint256 sushiBalanceDiff = sushiAfterBalance.sub(sushiBeforeBalance);
 
-        balances[msg.sender] = balances[msg.sender].sub(requiredShares);
+        balances[msg.sender] = balances[msg.sender].sub(requiredSharesBalance);
         sushi.transfer(msg.sender, sushiBalanceDiff);
         
         return (sushiBalanceDiff);

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -108,7 +108,7 @@ describe("SushiYieldSource", function () {
         await yieldSource.redeemToken(totalAmount);
         expect(await sushi.balanceOf(wallet.address)).to.be.closeTo(
           totalAmount,
-          1
+          2
         );
       }
     );


### PR DESCRIPTION
Positing that this is the correct requiredShares calculation method vs. that outlined in the Audit section 3.3

Subtracting one from the totalShares does not make a difference when flooring to the nearest integer value. 

Subtracting one outside the equation results in the desired result, withdrawing the maximum value allowable *and* callable with the result from `balanceOfToken()`. 

<img width="1133" alt="Screen Shot 2021-06-07 at 2 32 12 PM" src="https://user-images.githubusercontent.com/36907214/121090525-934caa00-c79d-11eb-9675-5f50f903a1ef.png">
